### PR TITLE
Add UIKit import in PDFExporter

### DIFF
--- a/CaddieManager/Utils/PDFExporter.swift
+++ b/CaddieManager/Utils/PDFExporter.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import PDFKit
+import UIKit
 
 struct PDFExporter {
     static func export(view: AnyView) {


### PR DESCRIPTION
## Summary
- include UIKit for UI rendering in PDFExporter

## Testing
- `xcodebuild -scheme CaddieManager -workspace CaddieManager.xcworkspace -configuration Release build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b0a97e740832384382c67c0b3bce6